### PR TITLE
Update recommended baseline to single global Private DNS zone (2026 refresh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This article assumes familiarity with the concepts of Azure Private Link, DNS an
 - https://aka.ms/whatisprivatelink - Introductory video on Private Link
 - https://aka.ms/whyprivatelink - High level white paper exploring the requirement for Private Link
 - https://aka.ms/privatelinkdns - Technical white paper introducing the DNS challenge when working with Private Link
-- Microsoft official documentation on Private Link DNS integration, https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns
+- Microsoft official documentation on Private Link DNS integration, https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
 - Daniel Mauser's excellent collection of articles related to Private link, https://github.com/dmauser/PrivateLink
 
 # 2. Introduction
@@ -64,7 +64,7 @@ This article discusses the topic of how best to design your use of **Azure DNS P
 
 ### 3.2.1. Optimal use of Azure Private Link / SDN
 
-The use of regional specific Azure DNS Private Zones allows multiple A records (across your global common Layer-3 routing domain) for a single PaaS service (an endpoint with the same FQDN). This ensures that your traffic destined for an Azure PaaS service always makes the most optimal use of the Azure SDN with Azure Private Link. Private Link is capable of [global](https://docs.microsoft.com/en-gb/azure/private-link/private-link-overview#:~:text=data%20leakage%20risks.-,Global%20reach,-%3A%20Connect%20privately%20to) transport by default; Private Endpoints in Region X can access PaaS resources in Region Y, with the communications between X and Y being handled transparently by the Microsoft platform.
+The use of regional specific Azure DNS Private Zones allows multiple A records (across your global common Layer-3 routing domain) for a single PaaS service (an endpoint with the same FQDN). This ensures that your traffic destined for an Azure PaaS service always makes the most optimal use of the Azure SDN with Azure Private Link. Private Link is capable of [global](https://learn.microsoft.com/en-gb/azure/private-link/private-link-overview#:~:text=data%20leakage%20risks.-,Global%20reach,-%3A%20Connect%20privately%20to) transport by default; Private Endpoints in Region X can access PaaS resources in Region Y, with the communications between X and Y being handled transparently by the Microsoft platform.
 
 E.g. In the diagram below, a Virtual Machine in Region B is attempting to access a PaaS resource that happens to be located in Region A. By utilising a regional Azure DNS Private Zone, and regional Private Endpoints, the A record that is returned represents an IP address within the local region. This ensures ingress into Private Link as close to the source as possible. The section of the purple data path line that transits between Azure Regions is then entirely handled by the underlying Azure platform, with no dependencies on the customer-managed routing domain or private network.
 
@@ -88,7 +88,7 @@ The use of regional specific Azure DNS Private Zones allows seamless failover of
 |:--:| 
 | <span style="font-size:0.8em;">Figure 3 - Azure Storage failover PaaS access with regional Azure DNS Private Zones</span> |
 
-This "hands off" approach to DNS logic upon regional failover also applies to all other Azure PaaS services, including those such as Azure SQL and Azure service bus that make use of Public DNS alias records with features such as [failover groups](https://docs.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-configure-sql-db?tabs=azure-portal&pivots=azure-sql-single-db#use-private-link).
+This "hands off" approach to DNS logic upon regional failover also applies to all other Azure PaaS services, including those such as Azure SQL and Azure service bus that make use of Public DNS alias records with features such as [failover groups](https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-configure-sql-db?tabs=azure-portal&pivots=azure-sql-single-db#use-private-link).
 
 ### 3.2.3. Azure DNS Private Zone management and automation
 
@@ -98,15 +98,15 @@ This approach, the use of regional zones, will result in multiple Azure DNS Priv
 |:--:| 
 | <span style="font-size:0.8em;">Figure 4 - Multiple privatelink.blob.core.windows.net Azure Private DNS Zones within the same portal view, note differing resource group names in column 4</span> |
 
-Secondly, if using pre-existing custom-built automation (or [Enterprise scale provided Azure Policy](https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale) [^3] ) to configure Azure DNS Private zones upon Private Endpoint creation, you may need to modify your code to support an operator to make your code Resource Zone specific. I.e. If you only specify the Azure DNS Private Zone name, this will not be specific enough, if you have multiple Azure DNS Private Zones with the same name.
+Secondly, if using pre-existing custom-built automation (or [Enterprise scale provided Azure Policy](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale) [^3] ) to configure Azure DNS Private zones upon Private Endpoint creation, you may need to modify your code to support an operator to make your code Resource Zone specific. I.e. If you only specify the Azure DNS Private Zone name, this will not be specific enough, if you have multiple Azure DNS Private Zones with the same name.
 
-[^3]: The team within Microsoft responsible for Enterprise Scale Landing Zones documentation are currently working on updating the automation associated with this topic to provide flexibility in its deployment, to cater for both architecture options presented in this article.
+[^3]: The canonical ALZ codification of Private Link DNS as of 2025 is the AVM pattern module [`avm/ptn/network/private-link-private-dns-zones`](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones), which deploys ~79 `privatelink.*` zones (all `location: 'global'`) in a single connectivity-subscription resource group and links them to a hub VNet. ALZ-Bicep retired its older `privateDnsZones` module in v0.20.0 in favour of this AVM module; ALZ Terraform (GA Jan 2025) ships the equivalent. The original 2022 footnote here said this work was in flight — it has long since landed.
 
 ### 3.2.4. Hybrid Private Link connectivity can be sub-optimal
 
 This approach, the use of regional zones, ultimately allows differing A records (across your global common Layer-3 routing domain) to be returned for the same FQDN, depending on which region returns the query. This makes complete sense, and enables the "in Azure" optimal use of Private Link as laid out in section 3.2.1. 
 
-However, when integrating [conditional forward from On-Premises](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns#on-premises-workloads-using-a-dns-forwarder) for Azure Private Link, we have to consider how this design has the potential to introduce sub-optimal routing. This ultimately boils down to which platform you are using for DNS infrastructure (E.g. Windows behaves differently to the latest BIND based software), checkout Appendix A on hybrid forwarding to fully understand this topic.
+However, when integrating [conditional forward from On-Premises](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#on-premises-workloads-using-a-dns-forwarder) for Azure Private Link, we have to consider how this design has the potential to introduce sub-optimal routing. This ultimately boils down to which platform you are using for DNS infrastructure (E.g. Windows behaves differently to the latest BIND based software), checkout Appendix A on hybrid forwarding to fully understand this topic.
 
 # 4. Architecture Option 2 – Single Global Azure DNS Private Zone (attached to all Azure Regions)
 
@@ -151,7 +151,7 @@ The use of a common global Azure DNS Private Zone presents a challenge when work
 
 This approach, the use of a single global Azure DNS private zone, ultimately allows returns the same A record (across your global common Layer-3 routing domain) for the same FQDN, regardless of which region returns the query. This makes can result in sub-optimal "in Azure" use of Private Link / SDN as laid out in section 4.2.1. 
 
-However, when integrating [conditional forward from On-Premises](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns#on-premises-workloads-using-a-dns-forwarder) for Azure Private Link, the single zone model does have benefits, wherein regardless of which platform you are using for DNS infrastructure (E.g. Windows behaves differently to the latest BIND based software), Private Link connectivity from On-Premises will always take the shortest network path. Checkout Appendix A on hybrid forwarding to fully understand this topic.
+However, when integrating [conditional forward from On-Premises](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#on-premises-workloads-using-a-dns-forwarder) for Azure Private Link, the single zone model does have benefits, wherein regardless of which platform you are using for DNS infrastructure (E.g. Windows behaves differently to the latest BIND based software), Private Link connectivity from On-Premises will always take the shortest network path. Checkout Appendix A on hybrid forwarding to fully understand this topic.
 
 # 5. Conclusion
 
@@ -182,7 +182,7 @@ Let us first consider a typical resilient hybrid DNS forwarding design for an En
 
 - A/B/C/D represent DNS forwarding functions, logically drawn as one box, in reality even these individual components will be resilient (pairs of DNS servers)
 - A typical forwarding configuration of A will often simply say "For an FQDN that lives in Azure, forward to C and D, with C being specified first in the list of forwarders. How A processes this list of forwarders, depends on the DNS software being used:
-  - Microsoft Windows Servers running the DNS service, [will always](https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/forwarders-resolution-timeouts#what-is-the-default-behavior-of-a-dns-server-when-more-than-two-dns-servers-are-configured-as-conditional-forwarders) use the first forwarder in the list (always send to C in our example). 
+  - Microsoft Windows Servers running the DNS service, [will always](https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/forwarders-resolution-timeouts#what-is-the-default-behavior-of-a-dns-server-when-more-than-two-dns-servers-are-configured-as-conditional-forwarders) use the first forwarder in the list (always send to C in our example). 
   - Older versions of BIND will exhibit the same behaviour as Windows
   - Modern versions of BIND (v9) implement a different algorithm in choosing the forwarders; they use an RTT/latency smoothing based behaviour. Long story short, is that in our example, **even if you put C first in your forwarders list, and C remains healthy, D will infrequently be used**
   - Infoblox, based on the latest BIND code, therefore exhibits the same behaviour - more info [here](https://community.infoblox.com/t5/nios-dns-dhcp-ipam/how-does-infoblox-select-forwarders/td-p/19945#:~:text=06%3A49%20AM-,Hello%20there%2C,-While%20using%20more)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Multi-region use of Azure Private Link
     - [4.1. Overview](#41-overview)
     - [4.2. Design considerations](#42-design-considerations)
         - [4.2.1. Cross-region client-to-PE traffic considerations](#421-cross-region-client-to-pe-traffic-considerations)
-        - [4.2.2. Manual DNS record management for shared-FQDN geo-redundant PaaS](#422-manual-dns-record-management-for-shared-fqdn-geo-redundant-paas)
+        - [4.2.2. Manual DNS intervention required for some Azure PaaS services](#422-manual-dns-intervention-required-for-some-azure-paas-services)
         - [4.2.3. Hybrid Private Link connectivity always optimal](#423-hybrid-private-link-connectivity-always-optimal)
 - [5. Conclusion](#5-conclusion)
     - [5.1. Note! Azure DNS Private Zones are a global resource](#51-note-azure-dns-private-zones-are-a-global-resource)
@@ -134,11 +134,14 @@ With this design, data between the source/client and the Private Endpoint relies
 |:--:| 
 | <span style="font-size:0.8em;">Figure 6 - Inter-region PaaS access with global Azure DNS Private Zone</span> |
 
-> **Important caveat — this concern only applies to a specific shape.** It arises when a *single* Private Endpoint in one region is consumed by clients in another region. CAF's recommendation for any service consumed regionally is to deploy a **Private Endpoint per region** (see [Private Link and DNS integration at scale](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale)). With per-region PEs, the VM→PE leg stays intra-region in **either** zone model — what differs is how DNS steers each client to its local PE, and whether that record can be resolved during a regional outage. The single-zone model with regional PEs is the common ALZ deployment shape today.
+> Note: deploying a Private Endpoint per region does **not** remove this characteristic on its own. A single Private DNS zone can only hold one A record per FQDN, so even where regional PEs exist, all linked VNets resolve to whichever PE registered the record — clients in the other region traverse the customer overlay to reach it. The per-region zone model is what allows the *same* FQDN to resolve to *different* PE IPs in different regions, keeping the VM→PE leg intra-region and pushing the inter-region transit onto the Microsoft-managed Private Link backbone.
 
-### 4.2.2. Manual DNS record management for shared-FQDN geo-redundant PaaS
+### 4.2.2. Manual DNS intervention required for some Azure PaaS services
 
-The single zone model has one specific awkward case: PaaS services where **the same FQDN must resolve to different IPs in different regions** during failover. The clearest example is Azure Storage GRS — both the primary and secondary endpoints share `<account>.blob.core.windows.net`, and only one Private Endpoint can be active for that FQDN at a time. Consider the following scenario:
+Failover behaviour with a single global zone splits PaaS services into two camps, governed by how each service implements its own regional resilience:
+
+- **Service-level FQDN/CNAME failover — single zone is fine.** Azure SQL (failover groups), Azure SQL Managed Instance, Azure Service Bus (Premium namespace pairing) and Azure Event Hubs all expose an abstracted cluster FQDN that is remapped to the active regional instance by the platform on failover. Resolution still lands on the original PE A record, but the underlying CNAME chain redirects to the now-active region with no DNS edit by the customer. Single global zone works seamlessly.
+- **Same-FQDN-different-IP services — manual intervention required.** Azure Storage (GRS/RA-GRS), Azure Site Recovery, Azure Key Vault, Azure Cosmos DB (where clients use the global account FQDN before SDK-side endpoint discovery), Azure Container Registry geo-replication, Power BI, and Azure Static Web Apps. The example below uses Storage:
 
 -	The red Virtual Machine is configured to access a blob storage account `test.blob.core.windows.net`, and under normal conditions does so via its local Private Endpoint
 -	You are also utilising Azure Site Recovery (ASR) to copy the VMs to Region B
@@ -152,9 +155,9 @@ The single zone model has one specific awkward case: PaaS services where **the s
 
 A few important nuances:
 
-- **The Private DNS zone resource itself is global and survives a regional outage.** Per [Azure Private DNS zone resiliency](https://learn.microsoft.com/azure/dns/private-dns-resiliency): *"DNS private zones are resilient to regional outages because zone data is globally available."* The "high RTO" framing earlier versions of this article used has aged poorly — the resiliency cost is bounded to the manual record update for the specific shared-FQDN services described above, not to general name resolution.
-- **CAF acknowledges this is fundamentally the same problem in either zone model.** Per [Private Link and DNS integration at scale](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale): *"This scenario requires manual maintenance and updates of the Private Link DNS record set in every region because there's currently no automated lifecycle management for these."* Per-region zones avoid the active/standby A-record juggle by holding *both* records in *separate* zones — operationally simpler in the storage GRS case, but it does not generalise.
-- **Services with region-tokenised FQDNs are a different shape.** Azure Container Apps (`privatelink.{regionName}.azurecontainerapps.io`), AKS API server (`privatelink.{regionName}.azmk8s.io`), Azure Backup, Kusto and Azure Monitor Prometheus include `{regionName}` or `{regionCode}` placeholders in their canonical FQDN. These naturally produce one zone per region of use without any active/standby ambiguity, and the AVM module handles them explicitly.
+- **A per-service breakdown is maintained separately.** See the companion [`adstuart/azure-privatelink-multiregion-services`](https://github.com/adstuart/azure-privatelink-multiregion-services) repo for the categorisation above kept up to date as Azure adds services.
+- **The Private DNS zone resource itself is global and survives a regional outage.** Per [Azure Private DNS zone resiliency](https://learn.microsoft.com/azure/dns/private-dns-resiliency): *"DNS private zones are resilient to regional outages because zone data is globally available."* The "high RTO" framing earlier versions of this article used has aged poorly — the resiliency cost is bounded to record management for the second category above, not to general name resolution.
+- **Services with region-tokenised FQDNs are a different shape entirely.** Azure Container Apps (`privatelink.{regionName}.azurecontainerapps.io`), AKS API server (`privatelink.{regionName}.azmk8s.io`), Azure Backup, Kusto and Azure Monitor Prometheus include `{regionName}` or `{regionCode}` placeholders in their canonical FQDN. These naturally produce one zone per region of use without any active/standby ambiguity, and the AVM module handles them explicitly.
 
 ### 4.2.3. Hybrid Private Link connectivity always optimal
 
@@ -170,7 +173,7 @@ Both designs are viable and functional, but they have different characteristics 
 
 **Per-region or per-spoke zones remain appropriate when:**
 
-- **Shared-FQDN geo-redundant PaaS** is in use (Azure Storage GRS/RA-GRS, SQL failover groups, Cosmos DB multi-region writes). The same FQDN must resolve to a different IP after failover; per-region zones avoid the active/standby A-record juggle. (See §4.2.2.)
+- **PaaS without service-level FQDN failover** is in use (Azure Storage GRS/RA-GRS, ASR, Key Vault, Cosmos DB, ACR geo-replication, Power BI, Static Web Apps). The same FQDN must resolve to a different IP after failover; per-region zones avoid the active/standby A-record juggle. (See §4.2.2 and the companion [`azure-privatelink-multiregion-services`](https://github.com/adstuart/azure-privatelink-multiregion-services) repo for the full per-service categorisation.)
 - **Strict tenant or sovereignty isolation** mandates segmentation by region or workload subscription. CAF actively discourages this with its `Deny-PrivateDNSZone-PrivateLink` policy by default — but the policy is a default, not a law.
 - **Cross-tenant Private Link** consumption, where the consumer cannot link to the producer's zone. Private DNS [`resolutionPolicy=NxDomainRedirect`](https://learn.microsoft.com/azure/dns/private-dns-fallback) may be the right tool here rather than zone duplication.
 - **BIND/Infoblox-based hybrid DNS environments** — see Appendix A. In some topologies the single global zone is materially simpler regardless of the points above.
@@ -179,9 +182,10 @@ Both designs are viable and functional, but they have different characteristics 
 
   | Criterion | Option 1 — Per-region zones | Option 2 — Single global zone |
   | --- | --- | --- |
-  | Optimal Private Link SDN traffic flows | Yes (with per-region PEs) | Yes with per-region PEs; sub-optimal only when a single PE in one region serves multi-region clients |
+  | Optimal Private Link SDN traffic flows | Yes — different A records returned per region keep VM→PE intra-region | Sub-optimal for cross-region clients — only one A record per FQDN, so non-local clients traverse the customer overlay to reach the registered PE |
   | Inter-region resilience of name resolution itself | Yes — independent regional zones | Yes — Private DNS zones are global resources whose data plane is regionally replicated ([resiliency doc](https://learn.microsoft.com/azure/dns/private-dns-resiliency)) |
-  | Seamless failover for shared-FQDN geo-redundant PaaS (storage GRS, SQL failover groups) | Yes (each region has its own A record) | Conditional — manual record update required |
+  | Seamless failover for services with service-level FQDN/CNAME failover (SQL, SQL MI, Service Bus, Event Hubs) | Yes | Yes — handled by the platform |
+  | Seamless failover for services without service-level FQDN failover (Storage, ASR, Key Vault, Cosmos DB, ACR, Power BI, Static Web Apps) | Yes (each region has its own A record) | Manual DNS record update required |
   | Optimal hybrid forwarding (BIND/Infoblox) | Maybe (see Appendix A) | Yes |
   | Operational consistency / drift risk | Higher — N copies to keep aligned | Lower — single source of truth |
   | Alignment with current CAF / ALZ / AVM guidance | Conditional (per-region scenarios above) | Default baseline |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Multi-region use of Azure Private Link
         - [4.2.3. Hybrid Private Link connectivity always optimal](#423-hybrid-private-link-connectivity-always-optimal)
 - [5. Conclusion](#5-conclusion)
     - [5.1. Note! Azure DNS Private Zones are a global resource](#51-note-azure-dns-private-zones-are-a-global-resource)
+    - [5.2. Further reading](#52-further-reading)
 - [6. Appendix A - Hybrid forwarding and multi-region Private Link considerations when accessing from On-Premises](#6-appendix-a---hybrid-forwarding-and-multi-region-private-link-considerations-when-accessing-from-on-premises)
     - [6.1. Baseline topology and Windows/BIND differences](#61-baseline-topology-and-windowsbind-differences)
     - [6.2. Hybrid Private Link access with Architecture Option 1 – Azure DNS Private Zone per Azure Region](#62-hybrid-private-link-access-with-architecture-option-1--azure-dns-private-zone-per-azure-region)
@@ -41,11 +42,13 @@ This article assumes familiarity with the concepts of Azure Private Link, DNS an
 
 # 2. Introduction
 
-At the time of writing, Azure Private Link has been Generally Available (GA) for around two years (since February 2020), therefore adoption of the service is now widespread amongst Azure customers. Naturally, these same customers often use services across multiple Azure regions. 
+Azure Private Link is now widely adopted, and most non-trivial Azure estates span multiple regions.
 
 When using Azure Private Link, one of the major considerations is how to handle DNS resolution and forwarding[^1].
 
-This article discusses the topic of how best to design your use of **Azure DNS Private Zones** when working with **Azure Private Link** across two (or more) Azure regions, often with the intention of designing for Disaster Recovery or Business Continuity (BCDR) scenarios. Specifically, it addresses the question of _"Should I utilise one common Azure DNS Private Zone attached to all Azure regions, or should I use region-specific zones?"_
+This article discusses how best to design your use of **Azure DNS Private Zones** when working with **Azure Private Link** across two (or more) Azure regions, often with the intention of designing for Disaster Recovery or Business Continuity (BCDR) scenarios. Specifically, it addresses the question of _"Should I utilise one common Azure DNS Private Zone attached to all Azure regions, or should I use region-specific zones?"_
+
+> **Update note (2026):** This article was originally written in 2022 and presented the two zone models as a balanced trade-off pivoted on "Complexity vs RTO". Since then Microsoft's Cloud Adoption Framework, Azure Landing Zones reference implementations (Bicep + Terraform), the AVM pattern module [`avm/ptn/network/private-link-private-dns-zones`](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones), and the Azure Architecture Center have all converged on the **single global Private DNS zone per `privatelink.*` namespace, hosted centrally and linked to all VNets** as the default baseline. The two-option walkthrough below is preserved as a deep-dive on the trade-offs; the conclusion and comparison table have been updated to reflect what holds up in 2026 vs what was a fair argument in 2022. See [Further reading](#52-further-reading) for current sources.
 
 [^1]: When working with Azure Private Link we are required to modify default DNS forwarding to make use of the Private Endpoints to access PaaS Services (And Azure Private Link Services) over private network connectivity. Specifically, by default, lookups to public FQDNs used by Microsoft PaaS Services (E.g. x.database.windows.net for Azure SQL) will return a public IP address. We have to modify the configuration of DNS to return a Private IP address which maps to the NIC used by a Private Endpoint. 
 
@@ -161,20 +164,65 @@ However, when integrating [conditional forward from On-Premises](https://learn.m
 
 # 5. Conclusion
 
-This document highlights that there is a key design decision to be made at the intersection of DNS design and use of the Azure Private Link technology; do I use a single global Azure Private DNS Zone, or do I use one per region?
+Both designs are viable and functional, but they have different characteristics — and the balance has shifted since this article was first written.
 
-The conclusion is that, whilst both designs are viable and functional, they do have differing characteristics that can effect both day-to-day BAU performance as well as the expected behaviour and associated RTO during a DR event. Which design is correct for your organisation will depend on many factors including IaaC-maturity and Global Scale level. 
+**Recommended baseline (2026):** Use a single global Private DNS zone for each `privatelink.*` namespace, centrally managed in the connectivity subscription and linked to all VNets that need resolution, with a Private Endpoint per region for any service consumed regionally. This is the pattern codified by the AVM pattern module [`avm/ptn/network/private-link-private-dns-zones`](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones), used by ALZ-Bicep and ALZ Terraform, and called out in CAF and the Azure Architecture Center.
 
-However, the main decision pivot is Complexity vs RTO, for a lot of customers, the single zone model will be perfectly acceptable (They are willing to accept a DR run-book that takes hours to complete, if it only needs using during a catastrophic failure aka region-down), where-as other customers will want to do as much as possible to ensure the DR process is automated. The table below attempts to summarise the pros/cons of each approach.
+**Per-region or per-spoke zones remain appropriate when:**
 
-  | - | Optimal Private Link SDN traffic flows  | Seamless BCDR of all PaaS service connectivity during "region down" event |  Optimal Hybrid forwarding | Automation complexity |
-  | ------------- | ------------- |   ------------- | ------------ | ------------ |
-  | Architecture Option 1 – Azure DNS Private Zone per Azure Region  | Yes  |   Yes (low RTO)  | Maybe (see Appendix A)|   High |
-  | Architecture Option 2 – Single Global Azure DNS Private Zone (attached to all Azure Regions)  | No |   No (High RTO) | Yes | Low |
+- **Shared-FQDN geo-redundant PaaS** is in use (Azure Storage GRS/RA-GRS, SQL failover groups, Cosmos DB multi-region writes). The same FQDN must resolve to a different IP after failover; per-region zones avoid the active/standby A-record juggle. (See §4.2.2.)
+- **Strict tenant or sovereignty isolation** mandates segmentation by region or workload subscription. CAF actively discourages this with its `Deny-PrivateDNSZone-PrivateLink` policy by default — but the policy is a default, not a law.
+- **Cross-tenant Private Link** consumption, where the consumer cannot link to the producer's zone. Private DNS [`resolutionPolicy=NxDomainRedirect`](https://learn.microsoft.com/azure/dns/private-dns-fallback) may be the right tool here rather than zone duplication.
+- **BIND/Infoblox-based hybrid DNS environments** — see Appendix A. In some topologies the single global zone is materially simpler regardless of the points above.
+
+**Updated comparison:**
+
+  | Criterion | Option 1 — Per-region zones | Option 2 — Single global zone |
+  | --- | --- | --- |
+  | Optimal Private Link SDN traffic flows | Yes (with per-region PEs) | Yes with per-region PEs; sub-optimal only when a single PE in one region serves multi-region clients |
+  | Inter-region resilience of name resolution itself | Yes — independent regional zones | Yes — Private DNS zones are global resources whose data plane is regionally replicated ([resiliency doc](https://learn.microsoft.com/azure/dns/private-dns-resiliency)) |
+  | Seamless failover for shared-FQDN geo-redundant PaaS (storage GRS, SQL failover groups) | Yes (each region has its own A record) | Conditional — manual record update required |
+  | Optimal hybrid forwarding (BIND/Infoblox) | Maybe (see Appendix A) | Yes |
+  | Operational consistency / drift risk | Higher — N copies to keep aligned | Lower — single source of truth |
+  | Alignment with current CAF / ALZ / AVM guidance | Conditional (per-region scenarios above) | Default baseline |
+  | Automation complexity | Higher | Lower |
 
 ## 5.1. Note! Azure DNS Private Zones are a global resource
 
-The benefits highlighted by "regional split brain" use of Azure Private DNS Zones for Azure Private link, are **not** a recommendation to abandon/forget the Global nature  Azure DNS Private Zones as an Azure resource in their entirety. In fact, for your own services (where you are using Azure DNS Private Zones for an internal forward lookup zone) the right approach _is_ normally to use a global zone. This is because, normally, the IP address (A record) returned by DNS, represents the destination of the service you are trying to access. The reason this fundamentally differs for Azure Private Link, is  that the IP address (A record) returned by DNS represents only the location of the Private Endpoint (PE), _not_ the destination/location of the finale PaaS service to be accessed.
+Even where this article walks through "regional split brain" use of Azure Private DNS Zones for Azure Private Link, that is **not** a recommendation to abandon the global nature of Azure DNS Private Zones in general. For your own services (where you use a Private DNS Zone as an internal forward lookup zone), a single global zone is normally the right approach.
+
+The historical reason this article presented Private Link as different was that an A record for `privatelink.*` represents the location of the Private Endpoint, not the location of the final PaaS service. With per-region Private Endpoints (which is the current CAF-recommended pattern), this distinction matters far less than it did when the article was first written — DNS still resolves to a regional PE, but the consumer side gets that benefit from PE placement rather than from zone segmentation.
+
+Per Microsoft's [Azure Private DNS zone resiliency](https://learn.microsoft.com/azure/dns/private-dns-resiliency): *"Azure DNS private zones are global resources … DNS private zones are resilient to regional outages because zone data is globally available."*
+
+## 5.2. Further reading
+
+Official Microsoft sources:
+
+- CAF — [Private Link and DNS integration at scale](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale)
+- CAF — [DNS for on-premises and Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/dns-for-on-premises-and-azure-resources)
+- Azure Architecture Center — [Private Link in a hub-and-spoke network](https://learn.microsoft.com/azure/architecture/networking/guide/private-link-hub-spoke-network)
+- [Azure Private Endpoint DNS integration scenarios](https://learn.microsoft.com/azure/private-link/private-endpoint-dns-integration)
+- [Azure Private Endpoint private DNS zone values](https://learn.microsoft.com/azure/private-link/private-endpoint-dns)
+- [Azure Private DNS zone resiliency](https://learn.microsoft.com/azure/dns/private-dns-resiliency)
+- [Azure DNS Private Resolver overview](https://learn.microsoft.com/azure/dns/dns-private-resolver-overview)
+- [Fallback to internet for Azure Private DNS zones (`resolutionPolicy=NxDomainRedirect`)](https://learn.microsoft.com/azure/dns/private-dns-fallback)
+
+ALZ / IaC modules:
+
+- AVM pattern module — [`avm/ptn/network/private-link-private-dns-zones`](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones)
+- [Azure Landing Zones (Terraform)](https://github.com/Azure/terraform-azurerm-avm-ptn-alz)
+
+Microsoft Tech Community blogs:
+
+- Ashish Rana — [DNS best practices for implementation in Azure Landing Zones](https://techcommunity.microsoft.com/blog/azurenetworkingblog/dns-best-practices-for-implementation-in-azure-landing-zones/4420567) (2025-06)
+- Andrew Coughlin — [Private Endpoint DNS Resolution with Azure Private Resolver for Multi-Region](https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/private-endpoint-dns-resolution-with-azure-private-resolver-for-multi-region/3679643)
+- deepthihr — [Private DNS and Hub–Spoke Networking for Enterprise AI Workloads on Azure](https://techcommunity.microsoft.com/blog/azureinfrastructureblog/private-dns-and-hub-spoke-networking-for-enterprise-ai-workloads-on-azure/4508835)
+- Stephane Eyskens — [Azure DNS Private Resolver topologies](https://techcommunity.microsoft.com/blog/azurenetworkingblog/azure-dns-private-resolver-topologies/3842634)
+
+Community / reference:
+
+- Daniel Mauser — [Private Endpoint DNS Integration Scenarios](https://github.com/dmauser/PrivateLink/tree/master/DNS-Integration-Scenarios)
 
 # 6. Appendix A - Hybrid forwarding and multi-region Private Link considerations when accessing from On-Premises
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Multi-region use of Azure Private Link
 - [4. Architecture Option 2 – Single Global Azure DNS Private Zone (attached to all Azure Regions)](#4-architecture-option-2--single-global-azure-dns-private-zone-attached-to-all-azure-regions)
     - [4.1. Overview](#41-overview)
     - [4.2. Design considerations](#42-design-considerations)
-        - [4.2.1. Sub-Optimal use of Azure Private Link / SDN](#421-sub-optimal-use-of-azure-private-link--sdn)
-        - [4.2.2. Manual DNS intervention required for inter-region failover of some Azure PaaS services when using Private Link](#422-manual-dns-intervention-required-for-inter-region-failover-of-some-azure-paas-services-when-using-private-link)
+        - [4.2.1. Cross-region client-to-PE traffic considerations](#421-cross-region-client-to-pe-traffic-considerations)
+        - [4.2.2. Manual DNS record management for shared-FQDN geo-redundant PaaS](#422-manual-dns-record-management-for-shared-fqdn-geo-redundant-paas)
         - [4.2.3. Hybrid Private Link connectivity always optimal](#423-hybrid-private-link-connectivity-always-optimal)
 - [5. Conclusion](#5-conclusion)
     - [5.1. Note! Azure DNS Private Zones are a global resource](#51-note-azure-dns-private-zones-are-a-global-resource)
@@ -121,31 +121,37 @@ However, when integrating [conditional forward from On-Premises](https://learn.m
 
 ## 4.2. Design considerations
 
-### 4.2.1. Sub-Optimal use of Azure Private Link / SDN
+### 4.2.1. Cross-region client-to-PE traffic considerations
 
-In the diagram below, showing the DNS and datapath in a scenario that uses a common global Azure DNS Private Zone. Notice how the datapath between Azure regions relies on the customer's existing inter-region routing solution E.g. ExpressRoute transit or Global VNet Peering. 
+In the diagram below the datapath between Azure regions relies on the customer's existing inter-region routing solution (Global VNet Peering, ExpressRoute, or a Virtual WAN hub) rather than the Microsoft-managed inter-region transport that Private Link can provide.
 
-With this design, data between the source/client and the Private Endpoint will rely more heavily on the Layer-3 routing provided by the customer's overlay Virtual Networking. This will increase cost and decrease performance and reliability, due to introducing additional hops made-up of customer specific components such as VNet Peering, ExpressRoute Circuits, ExpressRoute Gateways, NVAs and Routing/Security intent (NSG/UDR).
+With this design, data between the source/client and the Private Endpoint relies more heavily on the Layer-3 routing provided by the customer's overlay Virtual Networking, which can increase cost and add hops (VNet Peering, ExpressRoute Circuits, ExpressRoute Gateways, NVAs, NSG/UDR).
 
 | ![](images/2022-03-16-11-49-55.png) | 
 |:--:| 
 | <span style="font-size:0.8em;">Figure 6 - Inter-region PaaS access with global Azure DNS Private Zone</span> |
 
-### 4.2.2. Manual DNS intervention required for inter-region failover of some Azure PaaS services when using Private Link
+> **Important caveat — this concern only applies to a specific shape.** It arises when a *single* Private Endpoint in one region is consumed by clients in another region. CAF's recommendation for any service consumed regionally is to deploy a **Private Endpoint per region** (see [Private Link and DNS integration at scale](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale)). With per-region PEs, the VM→PE leg stays intra-region in **either** zone model — what differs is how DNS steers each client to its local PE, and whether that record can be resolved during a regional outage. The single-zone model with regional PEs is the common ALZ deployment shape today.
 
-The use of a common global Azure DNS Private Zone presents a challenge when working with the failover behaviour of Azure Storage. In the below diagram, please consider the following scenario.
+### 4.2.2. Manual DNS record management for shared-FQDN geo-redundant PaaS
 
--	The red Virtual Machine is configured to access a blob storage account test.blob.core.windows.net, and under normal conditions does so via its local Private Endpoint
--	You are also utilising Azure Site Recovery (ASR) to copy the VM’s to Region B
--	In a failure event, these VMs get re-inflated as Blue VMs in region B, and continue to use the same test.blob.core.windows.net FQDN for storage access
--	Using the green global Azure DNS Private Zone, a **remote** IP address is returned from a common A record, directing traffic to the **remote** Private Endpoint.This not only results in sub-optimal traffic flow (see section 2.2.1), but also a datapath that is now broken if Region A is offline/unavailable
--	User intervention (or complicated DR run-books)are required to change the global Azure DNS zone configuration to re-point the A records at the Blue Private Endpoints in order to reestablish the datapath to Azure Storage
+The single zone model has one specific awkward case: PaaS services where **the same FQDN must resolve to different IPs in different regions** during failover. The clearest example is Azure Storage GRS — both the primary and secondary endpoints share `<account>.blob.core.windows.net`, and only one Private Endpoint can be active for that FQDN at a time. Consider the following scenario:
+
+-	The red Virtual Machine is configured to access a blob storage account `test.blob.core.windows.net`, and under normal conditions does so via its local Private Endpoint
+-	You are also utilising Azure Site Recovery (ASR) to copy the VMs to Region B
+-	In a failure event, these VMs get re-inflated as Blue VMs in region B, and continue to use the same `test.blob.core.windows.net` FQDN for storage access
+-	With a single global zone, the A record still points at the Region A Private Endpoint, which may be unavailable
+-	A DNS record update is required to re-point the A record at the Region B Private Endpoint after the storage account fails over
 
 | ![](images/2022-03-16-11-57-03.png) | 
 |:--:| 
 | <span style="font-size:0.8em;">Figure 7 - Azure Storage failover PaaS access with global Azure DNS Private Zone</span> |
 
-> Information on Azure DNS Private Zones global failover https://learn.microsoft.com/en-us/azure/dns/private-dns-resiliency
+A few important nuances:
+
+- **The Private DNS zone resource itself is global and survives a regional outage.** Per [Azure Private DNS zone resiliency](https://learn.microsoft.com/azure/dns/private-dns-resiliency): *"DNS private zones are resilient to regional outages because zone data is globally available."* The "high RTO" framing earlier versions of this article used has aged poorly — the resiliency cost is bounded to the manual record update for the specific shared-FQDN services described above, not to general name resolution.
+- **CAF acknowledges this is fundamentally the same problem in either zone model.** Per [Private Link and DNS integration at scale](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale): *"This scenario requires manual maintenance and updates of the Private Link DNS record set in every region because there's currently no automated lifecycle management for these."* Per-region zones avoid the active/standby A-record juggle by holding *both* records in *separate* zones — operationally simpler in the storage GRS case, but it does not generalise.
+- **Services with region-tokenised FQDNs are a different shape.** Azure Container Apps (`privatelink.{regionName}.azurecontainerapps.io`), AKS API server (`privatelink.{regionName}.azmk8s.io`), Azure Backup, Kusto and Azure Monitor Prometheus include `{regionName}` or `{regionCode}` placeholders in their canonical FQDN. These naturally produce one zone per region of use without any active/standby ambiguity, and the AVM module handles them explicitly.
 
 ### 4.2.3. Hybrid Private Link connectivity always optimal
 


### PR DESCRIPTION
## Summary

Refresh the article so its recommended baseline reflects how Microsoft's public guidance has converged since this was first written in 2022. **Surgical edits, not a rewrite** — all figures, Appendix A, and the underlying two-option walkthrough are preserved.

This is still a community deep-dive on the trade-offs, not an MS doc — so the framing stays objective and behaviour-focused, with citations where claims are made.

## What's changed and why

**The 2022 framing was "Complexity vs RTO".** That argument hinged on one claim that no longer holds up cleanly: *"single global zone = high RTO during a region-down event."* The [Azure Private DNS zone resiliency](https://learn.microsoft.com/azure/dns/private-dns-resiliency) doc — which the repo already added a link to in Dec 2024 — explicitly states zone data is globally available and resilient to regional outages. The actual scope of "manual DNS in a DR event" is bounded to the subset of PaaS services that lack service-level FQDN/CNAME failover (Storage GRS/RA-GRS, ASR, Key Vault, Cosmos DB, ACR geo-replication, Power BI, Static Web Apps). Services with platform-managed CNAME failover — Azure SQL (failover groups), SQL MI, Service Bus Premium, Event Hubs — work seamlessly with a single zone, per the companion [`azure-privatelink-multiregion-services`](https://github.com/adstuart/azure-privatelink-multiregion-services) repo and Ch9 of the book.

**The cross-region SDN trade-off is real and preserved.** A single Private DNS zone can only hold one A record per FQDN, so even with regional PEs, non-local clients traverse the customer overlay to reach the registered PE. The per-region zone model is what uniquely enables the same FQDN to return different PE IPs per region. The article's §4.2.1 still spells this out — only the framing/heading has been made neutral, the technical content is unchanged.

**Meanwhile the codification has moved on:** ALZ-Bicep retired its `privateDnsZones` module in v0.20.0; ALZ Terraform (GA Jan 2025) and the AVM pattern module [`avm/ptn/network/private-link-private-dns-zones`](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/network/private-link-private-dns-zones) all deploy a single set of ~79 global `privatelink.*` zones in the connectivity subscription. CAF publishes a `Deny-PrivateDNSZone-PrivateLink` policy that prevents per-subscription duplication by default.

So the recommendation is flipped, and the comparison table is rewritten with conditional language. The **per-region case is still defended** for: PaaS without service-level FQDN failover, sovereignty isolation, cross-tenant Private Link, and BIND/Infoblox hybrid environments — readers with those requirements still get a clear path.

## Commits

1. **`chore: refresh learn.microsoft.com URLs and update ESLZ footnote`** — replace 8 `docs.microsoft.com` links with `learn.microsoft.com`. Footnote 3's claim that ESLZ was "currently working on" automation is 3 years stale; replace with a current pointer to the AVM module.
2. **`docs: reframe Option 2 sections 4.2.1 and 4.2.2`** — neutralise asymmetric "Sub-Optimal" / "Manual intervention required" headings without changing the technical claims underneath.
3. **`docs: update intro note, conclusion stance, comparison table, and add Further reading`** — drop the stale "GA for around two years" line, add a 2026 update-note callout. Conclusion now leads with the recommended baseline and lists the scenarios where per-region zones remain appropriate. New §5.2 Further reading.
4. **`fix: correct SDN claim and SQL failover categorisation`** — corrections after PR review: (a) the previous SDN caveat wrongly implied PE-per-region resolves the cross-region trade-off in either zone model — it doesn't, because a single zone holds only one A record per FQDN; (b) Azure SQL with failover groups belongs in the *seamless* bucket, not the manual one — service-level CNAME failover is platform-managed.

## What's preserved unchanged

- All 12 figures and image references
- The full Option 1 walkthrough (§3) — still presented as a valid pattern for the documented scenarios
- The Appendix A hybrid forwarding deep-dive — still the strongest pro-single-zone case in the document and still technically accurate
- Existing footnotes 1, 2 and the contributors section
- Overall section numbering (5.2 added as a sub-section of Conclusion to avoid renumbering)

## Sources cited in the new content

CAF *Private Link and DNS integration at scale*; CAF *DNS for on-premises and Azure resources*; Architecture Center *Private Link in a hub-and-spoke network*; *Azure Private DNS zone resiliency*; *DNS Private Resolver overview*; *Fallback to internet for Azure Private DNS zones*; AVM `avm/ptn/network/private-link-private-dns-zones`; companion repo [`adstuart/azure-privatelink-multiregion-services`](https://github.com/adstuart/azure-privatelink-multiregion-services); Tech Community posts by Ashish Rana, Andrew Coughlin, deepthihr, Stephane Eyskens; Daniel Mauser's PrivateLink GitHub repo.
